### PR TITLE
Updated docker-compose.yml to specify Neo4j 3.5 & Grafana 6.3.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 services:
 
   neo4j-core1:
-    image: neo4j:enterprise
+    image: neo4j:3.5-enterprise
     networks:
       - lan
     ports:
@@ -34,7 +34,7 @@ services:
     restart: unless-stopped
 
   neo4j-core2:
-    image: neo4j:enterprise
+    image: neo4j:3.5-enterprise
     networks:
       - lan
     ports:
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
 
   neo4j-core3:
-    image: neo4j:enterprise
+    image: neo4j:3.5-enterprise
     networks:
       - lan
     ports:
@@ -88,7 +88,7 @@ services:
     restart: unless-stopped
 
   neo4j-replica1:
-    image: neo4j:enterprise
+    image: neo4j:3.5-enterprise
     networks:
       - lan
     ports:
@@ -141,7 +141,7 @@ services:
     restart: always
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:6.3.7
     depends_on:
       - prometheus
     networks:


### PR DESCRIPTION
Changed Neo4j Docker image to specify 3.5, otherwise the Neo4j docker image will default to >4.0 and the example will not work.

Also changed version of Grafana to 6.3.7. (Similar issue)